### PR TITLE
Renamed Draw() any --> Take() (T, bool)

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -5,23 +5,23 @@ import (
 	"strings"
 )
 
-type Collection[Type comparable] interface {
-	Add(elements ...Type)
-	Draw() any
-	Contains(element Type) bool
+type Collection[T comparable] interface {
+	Add(vals ...T)
+	Take() (T, bool)
+	Contains(val T) bool
 	Clear()
 	Size() int
 	IsEmpty() bool
 }
 
 // Filter is the interface that wraps the basic Filter and Remove methods.
-type Filterable[Type comparable] interface {
-	Remove(element Type)
-	Filter(filter func(element Type) bool)
+type Filterable[T comparable] interface {
+	Remove(e T)
+	Filter(filter func(e T) bool)
 }
 
 // A Queue is a data structure that (in this implementation) maintains data in a FIFO (first-in-first-out) manner.
-// All elements added to the queue are added to the 'tail' end of the queue. Operations used to retrieve data - Poll()
+// All elements added to the queue are added to the 'tail' end of the queue. Operations used to retrieve data - Take()
 // and Peek() - return the value stored at the 'head' of the queue.
 //
 // This queue is implemented using nodes, not slices or arrays; this decision has it's tradeoffs. A node implementation
@@ -29,32 +29,32 @@ type Filterable[Type comparable] interface {
 // On the other hand, a node based implementation is not as performant when adding many values (batches) at a single time consistently.
 //
 // Therefore, another queue implementation will be added to cater to such a use case.
-type queue[Type comparable] struct {
-	head *node[Type]
-	tail *node[Type]
+type queue[T comparable] struct {
+	head *node[T]
+	tail *node[T]
 	size int
 }
 
 // A node is a data object that holds a value and a reference to a following node. Nodes are used
 // internally by the queue, and is therefore non-exportable.
-type node[Type comparable] struct {
-	val  Type
-	next *node[Type]
+type node[T comparable] struct {
+	val  T
+	next *node[T]
 }
 
 // Returns a new instance of a queue of the specified type.
-func New[Type comparable]() *queue[Type] {
-	return &queue[Type]{}
+func New[T comparable]() *queue[T] {
+	return &queue[T]{}
 }
 
 // Adds element(s) to the tail-end of the queue.
-func (q *queue[Type]) Add(elements ...Type) {
-	for _, elem := range elements {
+func (q *queue[T]) Add(vals ...T) {
+	for _, elem := range vals {
 		if q.head != nil {
-			q.tail.next = &node[Type]{val: elem, next: nil}
+			q.tail.next = &node[T]{val: elem, next: nil}
 			q.tail = q.tail.next
 		} else {
-			initialNode := &node[Type]{val: elem}
+			initialNode := &node[T]{val: elem}
 			q.head = initialNode
 			q.tail = initialNode
 		}
@@ -64,34 +64,36 @@ func (q *queue[Type]) Add(elements ...Type) {
 }
 
 // Returns the value of the head of the queue and removes it. If the queue is empty, returns nil.
-func (q *queue[Type]) Draw() any {
+func (q *queue[T]) Take() (T, bool) {
 	if q.size == 0 {
-		return nil
+		var zero T
+		return zero, false
 	}
 
 	val := q.head.val
 	q.head = q.head.next
 	q.size--
-	return val
+	return val, true
 }
 
 // Returns the value of the head of the queue but does not remove it. If the queue is empty, returns nil.
-func (q *queue[Type]) Peek() any {
+func (q *queue[T]) Peek() (T, bool) {
 	if q.size == 0 {
-		return nil
+		var zero T
+		return zero, false
 	}
 
-	return q.head.val
+	return q.head.val, true
 }
 
 // Removes all elements from the queue.
-func (q *queue[Type]) Clear() {
-	cleared := New[Type]()
+func (q *queue[T]) Clear() {
+	cleared := New[T]()
 	*q = *cleared
 }
 
 // Returns true if the queue contains the given element, returns false otherwise.
-func (q *queue[Type]) Contains(element Type) bool {
+func (q *queue[T]) Contains(element T) bool {
 	head := q.head
 	for head != nil {
 		if head.val == element {
@@ -104,8 +106,8 @@ func (q *queue[Type]) Contains(element Type) bool {
 }
 
 // Removes the first instance of the given element from the queue.
-func (q *queue[Type]) Remove(element Type) {
-	sentinel := &node[Type]{next: q.head}
+func (q *queue[T]) Remove(element T) {
+	sentinel := &node[T]{next: q.head}
 
 	for sentinel.next != nil {
 		if sentinel.next.val == element {
@@ -119,7 +121,7 @@ func (q *queue[Type]) Remove(element Type) {
 }
 
 // Filters all elements from the queue that satisfy the given predicate.
-func (q *queue[Type]) Filter(filter func(queueElement Type) bool) {
+func (q *queue[T]) Filter(filter func(queueElement T) bool) {
 	if q.head == nil {
 		return
 	}
@@ -141,17 +143,17 @@ func (q *queue[Type]) Filter(filter func(queueElement Type) bool) {
 }
 
 // Returns the amount of elements contained within the queue.
-func (q *queue[Type]) Size() int {
+func (q *queue[T]) Size() int {
 	return q.size
 }
 
 // Returns true if the queue contains no elements, otherwise returns false.
-func (q *queue[Type]) IsEmpty() bool {
+func (q *queue[T]) IsEmpty() bool {
 	return q.size == 0
 }
 
 // Returns a string representation of the queue. The larger the queue, the more expensive the operation.
-func (q *queue[Type]) String() string {
+func (q *queue[T]) String() string {
 	var stringBuilder strings.Builder
 	head := q.head
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -16,8 +16,8 @@ type Collection[T comparable] interface {
 
 // Filter is the interface that wraps the basic Filter and Remove methods.
 type Filterable[T comparable] interface {
-	Remove(e T)
-	Filter(filter func(e T) bool)
+	Remove(val T)
+	Filter(filter func(val T) bool)
 }
 
 // A Queue is a data structure that (in this implementation) maintains data in a FIFO (first-in-first-out) manner.
@@ -27,8 +27,6 @@ type Filterable[T comparable] interface {
 // This queue is implemented using nodes, not slices or arrays; this decision has it's tradeoffs. A node implementation
 // enables the addition and removal of a node to the queue to be O(1) and the memory used by the queue to be O(n) - always.
 // On the other hand, a node based implementation is not as performant when adding many values (batches) at a single time consistently.
-//
-// Therefore, another queue implementation will be added to cater to such a use case.
 type queue[T comparable] struct {
 	head *node[T]
 	tail *node[T]
@@ -106,11 +104,11 @@ func (q *queue[T]) Contains(element T) bool {
 }
 
 // Removes the first instance of the given element from the queue.
-func (q *queue[T]) Remove(element T) {
+func (q *queue[T]) Remove(val T) {
 	sentinel := &node[T]{next: q.head}
 
 	for sentinel.next != nil {
-		if sentinel.next.val == element {
+		if sentinel.next.val == val {
 			sentinel.next = sentinel.next.next
 			q.size--
 			return
@@ -121,7 +119,7 @@ func (q *queue[T]) Remove(element T) {
 }
 
 // Filters all elements from the queue that satisfy the given predicate.
-func (q *queue[T]) Filter(filter func(queueElement T) bool) {
+func (q *queue[T]) Filter(filter func(val T) bool) {
 	if q.head == nil {
 		return
 	}

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -33,9 +33,9 @@ func TestValidateQueue(t *testing.T) {
 		q.Add(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 		s := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-		isValid, msg := validateQueue(s, *q)
+		valid, msg := validateQueue(s, *q)
 
-		if !isValid {
+		if !valid {
 			t.Errorf("Expected to validate queue invalidated it instead!\nReturned message: %s", msg)
 		}
 	})
@@ -44,9 +44,9 @@ func TestValidateQueue(t *testing.T) {
 		q := New[int]()
 		s := []int{}
 
-		isValid, msg := validateQueue(s, *q)
+		valid, msg := validateQueue(s, *q)
 
-		if !isValid {
+		if !valid {
 			t.Errorf("Expected to validate queue invalidated it instead!\nReturned message: %s", msg)
 		}
 	})
@@ -56,9 +56,9 @@ func TestValidateQueue(t *testing.T) {
 		q.Add(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 		s := []int{1, 2, 3, 4, 8, 6, 7, 8, 9, 10}
 
-		isValid, msg := validateQueue(s, *q)
+		valid, msg := validateQueue(s, *q)
 
-		if isValid {
+		if valid {
 			t.Errorf("Expected method to fail but validated queue instead!\nReturned message: %s", msg)
 		}
 	})
@@ -68,9 +68,9 @@ func TestValidateQueue(t *testing.T) {
 		q.Add(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 		s := []int{1, 2, 3, 4}
 
-		isValid, msg := validateQueue(s, *q)
+		valid, msg := validateQueue(s, *q)
 
-		if isValid {
+		if valid {
 			t.Errorf("Expected method to fail but validated queue instead!\nReturned message: %s", msg)
 		}
 	})
@@ -82,8 +82,8 @@ func TestQueue_Add(t *testing.T) {
 		expectedOrdering := []int{1}
 		q.Add(1)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Add failed to add single element to queue! %s", msg)
 		}
 	})
@@ -94,8 +94,8 @@ func TestQueue_Add(t *testing.T) {
 
 		q.Add(1, 2, 3, 4)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Error(msg)
 		}
 	})
@@ -106,8 +106,8 @@ func TestQueue_Add(t *testing.T) {
 		q.Add(14, 62, 33, 1)
 		q.Add(23, 27, 52, 6)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Error(msg)
 		}
 	})
@@ -124,80 +124,81 @@ func TestQueue_Add(t *testing.T) {
 	})
 }
 
-func TestQueue_Poll(t *testing.T) {
-	t.Run("Poll Should Return Nil when Queue is Empty", func(t *testing.T) {
+func TestQueue_Take(t *testing.T) {
+	t.Run("Take Should Return Nil when Queue is Empty", func(t *testing.T) {
 		q := New[int]()
 
-		var val any = q.Draw()
+		val, drew := q.Take()
 
-		if val != nil {
-			t.Errorf("Poll failed! Expected 1 but got %v", val)
+		if drew != false && val != 0 {
+			t.Errorf("Take failed! Expected 1 but got %v", val)
 		}
 	})
 
-	t.Run("Poll Should Return Head of Queue", func(t *testing.T) {
+	t.Run("Take Should Return Head of Queue", func(t *testing.T) {
 		q := New[int]()
 		q.Add(1)
-		var val any = q.Draw()
 
-		if val != 1 {
-			t.Errorf("Poll failed! Expected 1 but got %v", val)
+		val, drew := q.Take()
+
+		if drew != true || val != 1 {
+			t.Errorf("Take failed! Expected 1 but got %v", val)
 		}
 	})
 
-	t.Run("Poll Should Maintain Order of Queue When Poll is Done on Single Value Queue", func(t *testing.T) {
+	t.Run("Take Should Maintain Order of Queue When Take is Done on Single Value Queue", func(t *testing.T) {
 		q := New[int]()
 		expectedOrdering := []int{5, 6, 7, 8}
 
 		q.Add(1)
-		q.Draw()
+		q.Take()
 		q.Add(5, 6, 7, 8)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Error(msg)
 		}
 	})
 
-	t.Run("Poll Should Maintain Order of Queue When Done Multiple Times", func(t *testing.T) {
+	t.Run("Take Should Maintain Order of Queue When Done Multiple Times", func(t *testing.T) {
 		q := New[int]()
 		expectedOrdering := []int{5, 6, 7, 8}
 
 		for i := 0; i < 5; i++ {
-			q.Draw()
+			q.Take()
 		}
 		q.Add(5, 6, 7, 8)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Error(msg)
 		}
 	})
 
-	t.Run("Poll Should Properly Decrease Size of Queue When Done Once", func(t *testing.T) {
+	t.Run("Take Should Properly Decrease Size of Queue When Done Once", func(t *testing.T) {
 		q := New[int]()
 		q.Add(1, 2, 3)
 
-		q.Draw()
+		q.Take()
 
 		size := q.Size()
 		if size != 2 {
-			t.Errorf("Poll failed to resize queue! Expected %d, got %d", 2, size)
+			t.Errorf("Take failed to resize queue! Expected %d, got %d", 2, size)
 		}
 	})
 
-	t.Run("Poll Should Properly Decrease Size of Queue When Done Multiple Times", func(t *testing.T) {
+	t.Run("Take Should Properly Decrease Size of Queue When Done Multiple Times", func(t *testing.T) {
 		q := New[int]()
 		q.Add(1, 2, 3, 4, 5, 6)
 		expectedSize := 2
 
 		for i := 0; i < 4; i++ {
-			q.Draw()
+			q.Take()
 		}
 
 		actualSize := q.Size()
 		if actualSize != expectedSize {
-			t.Errorf("Poll failed to resize queue! Expected %d, got %d", expectedSize, actualSize)
+			t.Errorf("Take failed to resize queue! Expected %d, got %d", expectedSize, actualSize)
 		}
 	})
 }
@@ -206,8 +207,8 @@ func TestQueue_Peek(t *testing.T) {
 	t.Run("Peek Should Return Nil When Queue is Empty", func(t *testing.T) {
 		q := New[int]()
 
-		val := q.Peek()
-		if val != nil {
+		val, peek := q.Peek()
+		if peek != false && val != 0 {
 			t.Errorf("Peek on empty queue resulted in a non-nil value, %v!", val)
 		}
 	})
@@ -216,8 +217,8 @@ func TestQueue_Peek(t *testing.T) {
 		q := New[int]()
 		q.Add(1)
 
-		val := q.Peek()
-		if val != 1 {
+		val, peek := q.Peek()
+		if peek != true || val != 1 {
 			t.Errorf("Peek on queue resulted in an unexpected value, %v!", val)
 		}
 	})
@@ -227,11 +228,11 @@ func TestQueue_Peek(t *testing.T) {
 		q.Add(1, 2, 3)
 
 		for i := 1; i <= q.size; i++ {
-			val := q.Peek()
-			if val != i {
+			val, peek := q.Peek()
+			if peek != true || val != i {
 				t.Errorf("Peek on queue resulted in an unexpected value!\nExpected: %v\nGot: %v", i, val)
 			}
-			q.head = q.head.next // Change head of the queue without using q.Poll()
+			q.head = q.head.next // Change head of the queue without using q.Take()
 		}
 	})
 }
@@ -275,8 +276,8 @@ func TestQueue_Clear(t *testing.T) {
 
 		q.Clear()
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Clear did not remove all elements from the queue! %s", msg)
 		}
 	})
@@ -316,8 +317,8 @@ func TestQueue_Filter(t *testing.T) {
 
 		q.Filter(isGreaterThanTen)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Filter removed elements from queue when given func is always false! %s", msg)
 		}
 	})
@@ -329,8 +330,8 @@ func TestQueue_Filter(t *testing.T) {
 
 		q.Filter(isLessThanOneHundred)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Filter did not remove elements from queue when given func is always true! %s", msg)
 		}
 	})
@@ -359,8 +360,8 @@ func TestQueue_Filter(t *testing.T) {
 
 		q.Filter(isGreaterThanTen)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Error(msg)
 		}
 	})
@@ -379,8 +380,8 @@ func TestQueue_Remove(t *testing.T) {
 
 		q.Remove(6)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Remove removed an element from the queue when it did not contain the given argument! %s", msg)
 		}
 	})
@@ -392,8 +393,8 @@ func TestQueue_Remove(t *testing.T) {
 
 		q.Remove(4)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Remove removed an element from the queue when it did not contain the given argument! %s", msg)
 		}
 	})
@@ -405,8 +406,8 @@ func TestQueue_Remove(t *testing.T) {
 
 		q.Remove(4)
 
-		isValid, msg := validateQueue(expectedOrdering, *q)
-		if !isValid {
+		valid, msg := validateQueue(expectedOrdering, *q)
+		if !valid {
 			t.Errorf("Remove removed an element from the queue when it did not contain the given argument! %s", msg)
 		}
 	})
@@ -460,7 +461,7 @@ func TestQueue_IsEmpty(t *testing.T) {
 			t.Error("Non-empty queue is returning true for IsEmpty()!")
 		}
 
-		q.Draw()
+		q.Take()
 
 		if !q.IsEmpty() {
 			t.Error("Empty Queue's IsEmpty() call returning false!")
@@ -506,4 +507,10 @@ func TestQueue_String(t *testing.T) {
 			t.Errorf("\nExpected: %s\nGot: %s", expectedString, actualString)
 		}
 	})
+}
+
+func TestQueueType(t *testing.T) {
+	var c Collection[int]
+	c = New[int]()
+	fmt.Println(c)
 }


### PR DESCRIPTION
Previously, the collection interface's data retrieval method was named Draw() and it returned a value of type `any`. This was restrictive however, and unclear, and so it the collection interface now defines the primary retrieval method as `Take() (T, bool)`. This way, the return type is the same type as the collection itself, and the user can identify whether or not the function succeeded by checking the bool value returned.